### PR TITLE
Add the default configured Oh Dear health application check route

### DIFF
--- a/etc/frontend/routes.xml
+++ b/etc/frontend/routes.xml
@@ -2,6 +2,9 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">
+        <route id="oh_dear_default" frontName="oh-dear-health-check-results">
+            <module name="Vendic_OhDear"/>
+        </route>
         <route id="oh_dear" frontName="oh-dear-health-application-check-results">
             <module name="Vendic_OhDear"/>
         </route>


### PR DESCRIPTION
Keep the custom one for backward compatibility.

This way, we don't have to enter a URL manually;

![image](https://github.com/user-attachments/assets/4f33c4b1-cb61-4f2f-9f06-c890daaf3df3)
