### PR TITLE
Redis Connection added enforce_redis constructor param

### DIFF
--- a/Checks/RedisConnection.php
+++ b/Checks/RedisConnection.php
@@ -20,7 +20,7 @@ class RedisConnection implements CheckInterface
         private DeploymentConfig $deploymentConfig,
         private Cache $cache,
         private CheckResultFactory $checkResultFactory,
-        private bool $enforce_redis = false
+        private bool $enforceRedis = false
     ) {
     }
 
@@ -43,7 +43,7 @@ class RedisConnection implements CheckInterface
 
         if ($this->checkisRedisEnabled($deploymentConfig) === false) {
             $checkResult->setStatus(
-                $this->enforce_redis ? CheckStatus::STATUS_FAILED : CheckStatus::STATUS_SKIPPED
+                $this->enforceRedis ? CheckStatus::STATUS_FAILED : CheckStatus::STATUS_SKIPPED
             );
             $checkResult->setShortSummary('Redis disabled');
             $checkResult->setNotificationMessage('Redis is not enabled');

--- a/Checks/RedisConnection.php
+++ b/Checks/RedisConnection.php
@@ -19,7 +19,8 @@ class RedisConnection implements CheckInterface
     public function __construct(
         private DeploymentConfig $deploymentConfig,
         private Cache $cache,
-        private CheckResultFactory $checkResultFactory
+        private CheckResultFactory $checkResultFactory,
+        private bool $enforce_redis = false
     ) {
     }
 
@@ -41,7 +42,9 @@ class RedisConnection implements CheckInterface
         );
 
         if ($this->checkisRedisEnabled($deploymentConfig) === false) {
-            $checkResult->setStatus(CheckStatus::STATUS_SKIPPED);
+            $checkResult->setStatus(
+                $this->enforce_redis ? CheckStatus::STATUS_FAILED : CheckStatus::STATUS_SKIPPED
+            );
             $checkResult->setShortSummary('Redis disabled');
             $checkResult->setNotificationMessage('Redis is not enabled');
             return $checkResult;

--- a/Test/Integration/Checks/RedisConnectionTest.php
+++ b/Test/Integration/Checks/RedisConnectionTest.php
@@ -25,4 +25,20 @@ class RedisConnectionTest extends TestCase
             'Redis connection check should be skipped when Redis is not enabled'
         );
     }
+
+    public function testRedisConnectionEnforceRedis(): void
+    {
+        /** @var RedisConnection $redisConnectionCheck */
+        $redisConnectionCheck = Bootstrap::getObjectManager()->create(RedisConnection::class, [
+            'enforce_redis' => true,
+        ]);
+
+        $output = $redisConnectionCheck->run();
+        $this->assertEquals('redis_connection', $output->getName());
+        $this->assertEquals(
+            CheckStatus::STATUS_FAILED,
+            $output->getStatus(),
+            'Redis connection check should be skipped when Redis is not enabled'
+        );
+    }
 }

--- a/Test/Integration/Checks/RedisConnectionTest.php
+++ b/Test/Integration/Checks/RedisConnectionTest.php
@@ -30,7 +30,7 @@ class RedisConnectionTest extends TestCase
     {
         /** @var RedisConnection $redisConnectionCheck */
         $redisConnectionCheck = Bootstrap::getObjectManager()->create(RedisConnection::class, [
-            'enforce_redis' => true,
+            'enforceRedis' => true,
         ]);
 
         $output = $redisConnectionCheck->run();


### PR DESCRIPTION
Added the `enforce_redis` constructor argument, that should return FAIL checkResult instead of SKIPPED on Redis connection fail