### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/Test/Integration/Checks/DatabaseConnectionCountsTest.php
+++ b/Test/Integration/Checks/DatabaseConnectionCountsTest.php
@@ -76,7 +76,7 @@ class DatabaseConnectionCountsTest extends TestCase
      * @param array|null $cachedData
      * @return void
      */
-    public function setupCache(ObjectManager $objectManager, array $cachedData = null): void
+    public function setupCache(ObjectManager $objectManager, ?array $cachedData = null): void
     {
         /** @var CacheService & MockObject $shellUtilsMock */
         $cacheServiceMock = $this->getMockBuilder(CacheService::class)


### PR DESCRIPTION
This PR fixes PHP 8.4 deprecation warnings by adding explicit nullable type declarations.