### PR TITLE
Fix integration tests for PHPUnit 12 (Magento 2.4.9): data provider attributes

### DIFF
--- a/Test/Integration/Checks/DatabaseConnectionCountsTest.php
+++ b/Test/Integration/Checks/DatabaseConnectionCountsTest.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Vendic\OhDear\Api\Data\CheckStatus;
@@ -38,9 +39,7 @@ class DatabaseConnectionCountsTest extends TestCase
         $this->assertEquals(CachedStatusResolver::STATUS_OK, $checkResult->getShortSummary());
     }
 
-    /**
-     * @dataProvider databaseConnectionCountDataProvider
-     */
+    #[DataProvider('databaseConnectionCountDataProvider')]
     public function testDatabaseConnectionCountWarning(
         int         $dbConnections,
         array $cachedData,

--- a/Test/Integration/Checks/PublicSqlFilesTest.php
+++ b/Test/Integration/Checks/PublicSqlFilesTest.php
@@ -7,6 +7,7 @@ namespace Vendic\OhDear\Test\Integration\Checks;
 
 use Magento\Framework\ObjectManager\ObjectManager;
 use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Vendic\OhDear\Api\Data\CheckStatus;
@@ -18,8 +19,8 @@ class PublicSqlFilesTest extends TestCase
 {
     /**
      * @magentoAppIsolation enabled
-     * @dataProvider dataProvider
      */
+    #[DataProvider('dataProvider')]
     public function testGetSqlFilesInPublicLocation(array $sqlFilesInPublicRoot, CheckStatus $expecedCheckStatus): void
     {
         /** @var \Magento\TestFramework\ObjectManager $objectManager */

--- a/Test/Integration/Checks/TwoFactorAuthenticationTest.php
+++ b/Test/Integration/Checks/TwoFactorAuthenticationTest.php
@@ -9,6 +9,7 @@ use Magento\Framework\Module\ModuleList;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TddWizard\Fixtures\Core\ConfigFixture;
@@ -41,9 +42,7 @@ class TwoFactorAuthenticationTest extends TestCase
         $this->configFixture = null;
     }
 
-    /**
-     * @dataProvider twoFactorAuthConfigDataProvider
-     */
+    #[DataProvider('twoFactorAuthConfigDataProvider')]
     public function testTwoFactorAuthWithConfig(
         string $configValue,
         CheckStatus $expectedStatus,

--- a/Test/Integration/Model/CachedStatusResolverTest.php
+++ b/Test/Integration/Model/CachedStatusResolverTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Integration\Model;
 
 use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Vendic\OhDear\Api\Data\CheckResultInterface;
 use Vendic\OhDear\Api\Data\CheckStatus;
@@ -92,9 +93,7 @@ class CachedStatusResolverTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider statusFlappingDataProvider
-     */
+    #[DataProvider('statusFlappingDataProvider')]
     public function testStatusChange(string $cachedStatus, CheckStatus $currentStatus, string $expectedStatus): void
     {
         $objectManager = Bootstrap::getObjectManager();
@@ -177,9 +176,7 @@ class CachedStatusResolverTest extends TestCase
         $this->assertEquals(CheckStatus::STATUS_WARNING->value, $cachedValue['status']);
     }
 
-    /**
-     * @dataProvider failStatusesDataProvider
-     */
+    #[DataProvider('failStatusesDataProvider')]
     public function testActualStatusChange(
         CheckStatus $status
     ) {


### PR DESCRIPTION
## Description
Magento 2.4.9 moves the test stack to PHPUnit 12, which removed support for metadata in doc-comments. The `@dataProvider` annotations in the integration tests are silently ignored there, so data-driven tests fail with `ArgumentCountError: Too few arguments`.

This PR converts the annotations to native `#[DataProvider]` attributes and makes the provider methods `public static`. Test logic is unchanged.

Compatible with PHPUnit 10.5 (Magento 2.4.8) and PHPUnit 12 (Magento 2.4.9).