### PR TITLE
PIPE-670: Fix undefined array key warning in Redis check on Magento 2.4.9

### DIFF
--- a/Checks/RedisConnection.php
+++ b/Checks/RedisConnection.php
@@ -4,6 +4,7 @@ namespace Vendic\OhDear\Checks;
 
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Setup\Model\ConfigOptionsList\Cache;
+use Magento\Setup\Model\ConfigOptionsList\PageCache;
 use Vendic\OhDear\Api\CheckInterface;
 use Vendic\OhDear\Api\Data\CheckResultInterface;
 use Vendic\OhDear\Api\Data\CheckStatus;
@@ -27,7 +28,12 @@ class RedisConnection implements CheckInterface
     public function run(): CheckResultInterface
     {
         $deploymentConfig = $this->deploymentConfig;
-        $options = [];
+        $options = [
+            Cache::INPUT_KEY_CACHE_BACKEND => $this->getBackendCacheType($deploymentConfig),
+            PageCache::INPUT_KEY_PAGE_CACHE_BACKEND => $deploymentConfig->get(
+                PageCache::CONFIG_PATH_PAGE_CACHE_BACKEND
+            ),
+        ];
         /** @var CheckResultInterface $checkResult */
 
         $checkResult = $this->checkResultFactory->create();


### PR DESCRIPTION
## Description

On Magento 2.4.9, the Oh Dear **Redis connection** check logged `Undefined array key "cache-backend"` (and `page-cache`) warnings to Sentry.

Core `Magento\Setup\Model\ConfigOptionsList\Cache::validateRedisConfig()` reads the `cache-backend` and `page-cache` option keys **without** null-coalescing:

```php
if ($options[self::INPUT_KEY_CACHE_BACKEND] == self::INPUT_VALUE_CACHE_VALKEY
    || $options[PageCache::INPUT_KEY_PAGE_CACHE_BACKEND] == PageCache::INPUT_VALUE_PAGE_CACHE_VALKEY) {
```

`RedisConnection::run()` called `Cache::validate($options, ...)` with `$options = []`. Previously harmless, because the cache backend was stored as the FQCN (`Magento\Framework\Cache\Backend\Redis`), which does not match core's `['redis','valkey']` list, so the validation branch that reaches `validateRedisConfig()` never ran.

Magento 2.4.9 switched the stored backend value to the short alias `redis` / `valkey` (the FQCN now silently falls back to file cache). With `backend => 'redis'`, the `!selectedBackend && currentBackend in ['redis','valkey']` branch now fires, reaches `validateRedisConfig()`, and hits the unguarded array access — producing the warnings.

## Fix

Populate `$options` with the configured cache and page-cache backend types so core's validation no longer reads undefined keys, while still validating the real Redis connection:

```php
$options = [
    Cache::INPUT_KEY_CACHE_BACKEND => $this->getBackendCacheType($deploymentConfig),
    PageCache::INPUT_KEY_PAGE_CACHE_BACKEND => $deploymentConfig->get(PageCache::CONFIG_PATH_PAGE_CACHE_BACKEND),
];
```

## Context

Triggered by PIPE-670 during the Magento 2.4.9 upgrade on the Harley project, after switching `app/etc/env.php` cache backend to the new `redis` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)