### PR TITLE
Fix CpuLoad test isolation leak

### DIFF
--- a/Test/Integration/Checks/CpuLoadTest.php
+++ b/Test/Integration/Checks/CpuLoadTest.php
@@ -71,12 +71,10 @@ class CpuLoadTest extends TestCase
         $cpuLoadUtilsMock->method('measure')
             ->willReturnOnConsecutiveCalls($result1Mock, $result2Mock, $result3Mock, $result4Mock, $result5Mock);
 
-        $objectManager->addSharedInstance($cpuLoadUtilsMock, CpuLoadUtils::class, true);
-
         // Run each test case
         foreach ($testCases as $index => $testCase) {
             /** @var CpuLoad $cpuLoadCheck */
-            $cpuLoadCheck = $objectManager->create(CpuLoad::class);
+            $cpuLoadCheck = $objectManager->create(CpuLoad::class, ['cpuLoadUtils' => $cpuLoadUtilsMock]);
             $checkResult = $cpuLoadCheck->run();
 
             $this->assertEquals('cpu_load', $checkResult->getName(), "Test case {$index}: {$testCase['message']}");
@@ -94,10 +92,8 @@ class CpuLoadTest extends TestCase
         $cpuLoadUtilsMock->method('measure')
             ->willThrowException(new LocalizedException(__('Cannot get CPU load')));
 
-        $objectManager->addSharedInstance($cpuLoadUtilsMock, CpuLoadUtils::class, true);
-
         /** @var CpuLoad $cpuLoadCheck */
-        $cpuLoadCheck = $objectManager->create(CpuLoad::class);
+        $cpuLoadCheck = $objectManager->create(CpuLoad::class, ['cpuLoadUtils' => $cpuLoadUtilsMock]);
         $checkResult = $cpuLoadCheck->run();
 
         $this->assertEquals('cpu_load', $checkResult->getName());


### PR DESCRIPTION
### Problem
`Checks\CpuLoadTest` registers a mocked `CpuLoadUtils` in the shared object manager with `addSharedInstance()` and never removes it. Depending on test execution order (surfaced by the PHPUnit 12 / PHP 8.4 run), `Utils\CpuLoadTest::testCreateCpuLoadResult` then picks up that leftover mock via `get(CpuLoadUtils::class)` and fails with `Cannot get CPU load` — even though the real util works fine.

### Fix
Inject the mock as a constructor argument of the `CpuLoad` check via `create(CpuLoad::class, ['cpuLoadUtils' => $mock])` instead of mutating the shared container. No global state is touched, so nothing leaks and no teardown is needed. Test-only change.